### PR TITLE
add select-one to form factory

### DIFF
--- a/src/modules/form/classes/Common/FormFactory.class.php
+++ b/src/modules/form/classes/Common/FormFactory.class.php
@@ -80,6 +80,7 @@ class FormFactory {
         $formitem = new \Quanta\Qtags\FormItemHidden($env, $input, $form);
         break;
       case 'select':
+      case 'select-one':
         $formitem = new \Quanta\Qtags\FormItemSelect($env, $input, $form);
         break;
       case 'checkboxes':


### PR DESCRIPTION
I added the select-one to form factory
Because when using the range in select, the type appears in the input as select-one
When you perform a validation for this type, because it does not exist in the form factory, it will be treated as a string
This causes problems