### PR TITLE
add ajax form to quanta

### DIFF
--- a/src/modules/form/assets/js/form.js
+++ b/src/modules/form/assets/js/form.js
@@ -140,3 +140,43 @@ $(document).bind('shadow_open', function() {
   });
 });
 
+$(document).ready(function() {
+  // Attach the submit handler to the form
+  $('.ajxa-form').on('submit', function(event) {
+      submitFormViaAjax(event, this);
+  });
+ });
+function submitFormViaAjax(e,form) {
+  e.preventDefault(); // Prevent the default form submission
+  formId = `#${$(form).attr('id')}`;
+  // Serialize form data
+  var formData = $(formId).serialize();
+  $(formId).css('opacity', '0.5');
+  var submitButton = $(formId).find('input[type="submit"]');
+
+  // Add the 'shadow-submitted' class to the submit button
+  submitButton.addClass('shadow-submitted');
+  // Send AJAX request
+  $.ajax({
+      url: '/',
+      type: 'POST',
+      data: formData,
+      
+      success: function(response) {
+          $(formId+'_confirm_message').show(); 
+          $(formId).find('.submit-error-message').hide();
+          $(formId).hide();
+      },
+      error: function(xhr, status, error) {
+          submitButton.removeClass('shadow-submitted');
+          $(formId).css('opacity', '1');
+          // Parse the response JSON
+          var errorResponse = JSON.parse(xhr.responseText);
+          // Extract the error message
+          var errorMessage = errorResponse.errors.message[0];
+          $(formId).find('.submit-error-message').text(errorMessage).show();
+          grecaptcha.reset();
+      }
+  });
+}
+

--- a/src/modules/form/classes/Qtags/Form.qtag.php
+++ b/src/modules/form/classes/Qtags/Form.qtag.php
@@ -36,6 +36,9 @@ class Form extends HtmlTag {
     if (!empty($this->getAttribute('name'))) {
       $this->setId($this->getAttribute('name'));
     }
+    if (!empty($this->getAttribute('ajax'))) {
+      $this->html_params['class'] .= ' ' . 'ajxa-form';
+    }
     $this->form_state->setType($this->getAttribute('type'));
     $this->html_params['action'] = !empty($this->getAttribute('action')) ? $this->getAttribute('action') : '?';
     $this->html_params['target'] = !empty($this->getAttribute('target')) ? $this->getAttribute('target') : '_top';


### PR DESCRIPTION
Now we can add Ajax param to the form qtag and the form will be submitted with Ajax request
To show a success message you can add an HTML tag with id: formId_confirm_message
And to show an error message you can add an HTML tag with class submit-error-message
Example:
```
  <div id="feedback_confirm_message" class="confirm-message hidden"><b>[TEXT|tag=feedback-confirm-message:Il tuo messaggio è stato ricevuto Grazie]</div>
    {FORM|name=feedback|ajax:
  [HTML_TAG:{TEXT|tag=feedback-intro:Il tuo feedback è importante per noi. Facci sapere come sta andando il tuo soggiorno!}]
  <span class="hidden submit-error-message">[TEXT|tag=submit-form-error:Si è verificato un errore durante l'invio. Per favore riprova più tardi]</span>
    }
```