### PR TITLE
add int cast to float

### DIFF
--- a/src/modules/image/classes/Common/Image.class.php
+++ b/src/modules/image/classes/Common/Image.class.php
@@ -370,7 +370,7 @@ class Image extends FileObject {
             // new dimensions and axis values.
 
             imagecopyresampled($tmp2img, $tmpimg, 0, 0,
-                $x_axis, $y_axis,
+                (int)$x_axis, (int)$y_axis,
                 $img_thumb_width,
                 $img_thumb_height,
                 $img_thumb_width,


### PR DESCRIPTION
PHP 8.1 introduced a deprecation warning for implicit conversion of floats to integers. This means that if you're directly using a float value where an integer is expected without explicitly casting it, you'll get a warning. This change is aimed at preventing unintended data loss and improving code clarity.