### PR TITLE
fix jumper query logic and add way to remove forced option

### DIFF
--- a/src/modules/jumper/assets/js/jumper.js
+++ b/src/modules/jumper/assets/js/jumper.js
@@ -8,7 +8,9 @@ var refreshJumpers = function() {
             var field = $(this).data('field');
 
           if (method == 'querystring') {
-              top.location.href = '?' + field + "=" + $(this).val();
+                const url = new URL(top.location.href);                
+                url.searchParams.set(field, $(this).val());
+                top.location.href = url.toString();
           }
           else if (method == 'nothing') {
               // Used for empty jumpers.

--- a/src/modules/jumper/classes/Qtags/Jumper.qtag.php
+++ b/src/modules/jumper/classes/Qtags/Jumper.qtag.php
@@ -50,7 +50,7 @@ class Jumper extends Qtag {
     // TODO: use FORM Qtags.
     $jumper = '<select class="jumper" data-field="' . $field . '" data-jumper-method="' . $method. '" rel="' . $ajax . '" ' . $tpl . '>'.
       (($empty_path != $default_path) ? ('<option value="' . $default_path . '">' . $default_title . '</option>') : '') .
-      '<option value="' . $empty_path . '">' . $empty_title . '</option>' .
+      ($this->attributes['empty_show'] !='false' ?'<option value="' . $empty_path . '">' . $empty_title . '</option>':'') .
       $dirlist->render() . '</select>';
 
     return $jumper;


### PR DESCRIPTION
add correct logic for querystring so it doesnt remove all query string that was set instead add if not present.
add a way to not force the empty option in the select. (to use just pass empty_show=false)