### PR TITLE
fix empty replace param to accept html

### DIFF
--- a/src/modules/qtags/classes/Qtags/HtmlTag.qtag.php
+++ b/src/modules/qtags/classes/Qtags/HtmlTag.qtag.php
@@ -47,7 +47,7 @@ class HtmlTag extends Qtag {
     }
     foreach ($this->html_params as $param_name => $param_value) {
       // check if param value is html tag and escape it
-      if ($param_value !== strip_tags($param_value)) {
+      if (isset($this->attributes['html_escape_params']) && $param_value !== strip_tags($param_value)) {
         $param_value = htmlspecialchars($param_value);
       }
       if (!empty($param_name)) {

--- a/src/modules/qtags/classes/Qtags/HtmlTag.qtag.php
+++ b/src/modules/qtags/classes/Qtags/HtmlTag.qtag.php
@@ -46,6 +46,10 @@ class HtmlTag extends Qtag {
     	}
     }
     foreach ($this->html_params as $param_name => $param_value) {
+      // check if param value is html tag and escape it
+      if ($param_value !== strip_tags($param_value)) {
+        $param_value = htmlspecialchars($param_value);
+      }
       if (!empty($param_name)) {
         $html .= $param_name . '="' . $param_value . '"';
       }


### PR DESCRIPTION
We can use this approach to fix empty_replace to accept html tag this way we can make missing data qtag as it was