### PR TITLE
empty_replace better fix

### DIFF
--- a/src/modules/qtags/classes/Qtags/Qtag.class.php
+++ b/src/modules/qtags/classes/Qtags/Qtag.class.php
@@ -166,8 +166,11 @@ class Qtag implements \Quanta\Common\Cacheable {
       }
       if (!empty($this->attributes['empty_replace'])) {
         // allow self closed tags
-        $allowed_tags='<br><img><hr>';
-        if (empty(strip_tags(trim($this->html),$allowed_tags)) && $this->attributes['class'] != 'icon') {
+        $allowed_tags = ['br','img','hr','input'];
+        if(isset($this->attributes['allowed_empty_tags'])) {
+          $allowed_tags = array_merge($allowed_tags,explode(',',$this->attributes['allowed_empty_tags']));
+        }
+        if (empty(strip_tags(trim($this->html),$allowed_tags))) {
           $this->html = $this->attributes['empty_replace'];
         }
       }


### PR DESCRIPTION
we can add any html tag to allow if empty ex : $this->attributes['allowed_empty_tags'] = 'span'

strip_tags can accept array in php 7+