### PR TITLE
fix empty_replace

### DIFF
--- a/src/modules/qtags/classes/Qtags/Qtag.class.php
+++ b/src/modules/qtags/classes/Qtags/Qtag.class.php
@@ -170,7 +170,8 @@ class Qtag implements \Quanta\Common\Cacheable {
         if(isset($this->attributes['allowed_empty_tags'])) {
           $allowed_tags = array_merge($allowed_tags,explode(',',$this->attributes['allowed_empty_tags']));
 	}
-          if (empty(strip_tags(trim($this->html),$allowed_tags))) {
+          // Check if $this->html is not empty before using strip_tags
+          if (empty($this->html) || empty(strip_tags(trim($this->html),$allowed_tags))) {
             $this->html = $this->attributes['empty_replace'];
 	  }
       }

--- a/src/modules/qtags/classes/Qtags/Qtag.class.php
+++ b/src/modules/qtags/classes/Qtags/Qtag.class.php
@@ -170,11 +170,9 @@ class Qtag implements \Quanta\Common\Cacheable {
         if(isset($this->attributes['allowed_empty_tags'])) {
           $allowed_tags = array_merge($allowed_tags,explode(',',$this->attributes['allowed_empty_tags']));
 	}
-	if (!empty($this->html)) {
-          if (empty(strip_tags(trim($this->html),$allowed_tags)) && ((!isset($this->attributes['class'])) || (isset($this->attributes['class']) && $this->attributes['class'] != 'icon'))) {
+          if (empty(strip_tags(trim($this->html),$allowed_tags))) {
             $this->html = $this->attributes['empty_replace'];
 	  }
-	}
       }
       // Prevent replacement where no_qtags attribute present. Used for input forms etc.
       if (isset($this->attributes['no_qtags'])) {


### PR DESCRIPTION
	if (!empty($this->html)) {
this check will make almost all qtags empty_replace not work and the other check if class=icon is not nessecary